### PR TITLE
Add scopes to waves

### DIFF
--- a/lua/slang-server/_commands/addToWaves.lua
+++ b/lua/slang-server/_commands/addToWaves.lua
@@ -9,6 +9,8 @@ M.addToWaves = {
       local handlers = require("slang-server.handlers")
       local ui = require("slang-server._core.ui")
 
+      local recursive = args[1] == "true"
+
       local bufnr = vim.api.nvim_get_current_buf()
 
       client.getInstances(bufnr, {
@@ -18,8 +20,7 @@ M.addToWaves = {
                return
             end
             if #resp == 1 then
-               -- TODO -- scopes
-               client.variableToWaveform(bufnr, handlers.defaultHandlers, { hierPath = resp[1].path })
+               client.addToWaveform(bufnr, handlers.defaultHandlers, { inst = resp[1], recursive = recursive })
             else
                local lines = {}
                for i = 1, #resp do
@@ -28,7 +29,7 @@ M.addToWaves = {
                local menu = ui.components.menu("Add instance to waves", {
                   lines = lines,
                   on_submit = function(item)
-                     client.variableToWaveform(bufnr, handlers.defaultHandlers, { hierPath = item.inst.path })
+                     client.addToWaveform(bufnr, handlers.defaultHandlers, { inst = item.inst, recursive = recursive })
                   end,
                })
                menu:mount()

--- a/lua/slang-server/_commands/openWaveform.lua
+++ b/lua/slang-server/_commands/openWaveform.lua
@@ -11,7 +11,7 @@ M.openWaveform = {
       local file = args[1]
       client.openWaveform(vim.api.nvim_get_current_buf(), handlers.defaultHandlers, { uri = file })
    end,
-   complete = require("slang-server.util").complete_path
+   complete = require("slang-server.util").complete_path,
 }
 
 return M

--- a/lua/slang-server/_lsp/client.lua
+++ b/lua/slang-server/_lsp/client.lua
@@ -110,22 +110,20 @@ end
 
 ---@param bufnr integer
 ---@param handlers RespHandlers
----@param params { hierPath: string }
-M.variableToWaveform = function(bufnr, handlers, params)
-   lsp_execute(bufnr, {
-      command = "slang.variableToWaveform",
-      arguments = { params.hierPath },
-   }, handlers)
-end
-
----@param bufnr integer
----@param handlers RespHandlers
----@param params { hierPath: string }
-M.scopeToWaveform = function(bufnr, handlers, params)
-   lsp_execute(bufnr, {
-      command = "slang.scopeToWaveform",
-      arguments = { params.hierPath },
-   }, handlers)
+---@param params { inst: slang-server.lsp.Instance, recursive: boolean}
+M.addToWaveform = function(bufnr, handlers, params)
+   if params.inst.kind == "Simple" then
+      lsp_execute(bufnr, {
+         command = "slang.variableToWaveform",
+         arguments = { params.inst.path },
+      }, handlers)
+   else
+      lsp_execute(bufnr, {
+         command = "slang.scopeToWaveform",
+         -- TODO -- do we need this extra level of container for slang command args?
+         arguments = { { path = params.inst.path, recursive = params.recursive } },
+      }, handlers)
+   end
 end
 
 return M

--- a/lua/slang-server/_lsp/types.lua
+++ b/lua/slang-server/_lsp/types.lua
@@ -37,3 +37,12 @@
 ---@alias slang-server.lsp.Node slang-server.lsp.Item | slang-server.lsp.Var | slang-server.lsp.Scope | slang-server.lsp.FilledInstance
 
 ---@alias RespHandlers {on_success: fun(resp: any), on_failure?: fun(message: string)}
+
+---@alias slang-server.InstanceKind
+---| '"Cell"'
+---| '"Aggregate"'
+---| '"Simple"'
+
+---@class slang-server.lsp.Instance
+---@field kind slang-server.InstanceKind
+---@field path string


### PR DESCRIPTION
Replaced `variableToWaveform` with `addToWaveform` which handles both simple variables and scopes / aggregate variables.  WCP calls both of them "scopes" which isn't technical correct, but oh well.