### PR TITLE
simplify getInstance() API

### DIFF
--- a/lua/slang-server/_commands/addToWaves.lua
+++ b/lua/slang-server/_commands/addToWaves.lua
@@ -20,16 +20,16 @@ M.addToWaves = {
                return
             end
             if #resp == 1 then
-               client.addToWaveform(bufnr, handlers.defaultHandlers, { inst = resp[1], recursive = recursive })
+               client.addToWaveform(bufnr, handlers.defaultHandlers, { path = resp[1], recursive = recursive })
             else
                local lines = {}
-               for i = 1, #resp do
-                  table.insert(lines, ui.NuiMenu.item(resp[i].path, { inst = resp[i] }))
+               for _, path in ipairs(resp) do
+                  table.insert(lines, ui.NuiMenu.item(path))
                end
                local menu = ui.components.menu("Add instance to waves", {
                   lines = lines,
                   on_submit = function(item)
-                     client.addToWaveform(bufnr, handlers.defaultHandlers, { inst = item.inst, recursive = recursive })
+                     client.addToWaveform(bufnr, handlers.defaultHandlers, { path = item.text, recursive = recursive })
                   end,
                })
                menu:mount()

--- a/lua/slang-server/_lsp/client.lua
+++ b/lua/slang-server/_lsp/client.lua
@@ -110,20 +110,12 @@ end
 
 ---@param bufnr integer
 ---@param handlers RespHandlers
----@param params { inst: slang-server.lsp.Instance, recursive: boolean}
+---@param params { path: string, recursive: boolean }
 M.addToWaveform = function(bufnr, handlers, params)
-   if params.inst.kind == "Simple" then
-      lsp_execute(bufnr, {
-         command = "slang.variableToWaveform",
-         arguments = { params.inst.path },
-      }, handlers)
-   else
-      lsp_execute(bufnr, {
-         command = "slang.scopeToWaveform",
-         -- TODO -- do we need this extra level of container for slang command args?
-         arguments = { { path = params.inst.path, recursive = params.recursive } },
-      }, handlers)
-   end
+   lsp_execute(bufnr, {
+      command = "slang.addToWaveform",
+      arguments = { params },
+   }, handlers)
 end
 
 return M

--- a/lua/slang-server/_lsp/types.lua
+++ b/lua/slang-server/_lsp/types.lua
@@ -37,12 +37,3 @@
 ---@alias slang-server.lsp.Node slang-server.lsp.Item | slang-server.lsp.Var | slang-server.lsp.Scope | slang-server.lsp.FilledInstance
 
 ---@alias RespHandlers {on_success: fun(resp: any), on_failure?: fun(message: string)}
-
----@alias slang-server.InstanceKind
----| '"Cell"'
----| '"Aggregate"'
----| '"Simple"'
-
----@class slang-server.lsp.Instance
----@field kind slang-server.InstanceKind
----@field path string


### PR DESCRIPTION
I refactored the slang server side of this to push determination of what kind of WCP thing we're talking about back into the server.  That simplifies both this code and `getInstances()` back on the server.